### PR TITLE
fix bug `Uncaught ReferenceError: parseHtml is not defined`

### DIFF
--- a/lib/htmlParse.js
+++ b/lib/htmlParse.js
@@ -29,7 +29,7 @@ function pushText(parent, text) {
 }
 
 
-export default parseHtml = function (html, done) {
+export default function (html, done) {
     //var startTime = new Date().getTime()
 
     let rootStack = [{

--- a/lib/htmlRender.js
+++ b/lib/htmlRender.js
@@ -98,7 +98,7 @@ const htmlToElement = function (rawHtml, opts, done) {
                 return null;
 
             if (node.type == 'inline') {
-                uri = node.attribs.href;
+                let uri = node.attribs.href;
                 if (name == 'a') {
                     return (
                         <Text


### PR DESCRIPTION
fix bug `Uncaught ReferenceError: parseHtml is not defined` when `npm run web` without `./post_npm_install.sh` in https://github.com/soliury/noder-react-native/tree/087d1d7fe22c170f35ff53f6b8064f704678320d

然后请记得发个新版到 https://www.npmjs.com/package/react-native-html-render 上啊 :smile: 
